### PR TITLE
A few updates

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,4 @@
 name = "noecowebsite"
 pages_build_output_dir = ".svelte-kit/cloudflare"
-compatibility_date = "2024-12-18"
+[vars]
+NODE_VERSION = "22"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,3 @@
 name = "noecowebsite"
 pages_build_output_dir = ".svelte-kit/cloudflare"
-
-[vars]
-NODE_VERSION=22
+compatibility_date = "2024-12-18"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,5 @@
 name = "noecowebsite"
 pages_build_output_dir = ".svelte-kit/cloudflare"
+
+[vars]
+NODE_VERSION=22


### PR DESCRIPTION
This pull request includes updates to various dependencies in the `package.json` and `pnpm-lock.yaml` files. The most important changes include updating the versions of several Svelte-related packages and other dependencies to their latest versions.

Dependency updates:

* Updated `@sveltejs/adapter-cloudflare` from `^4.8.0` to `^4.9.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-R77) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL863-R864)
* Updated `@sveltejs/kit` from `^2.12.1` to `^2.15.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-R77) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL875-R876)
* Updated `svelte` from `^5.14.4` to `^5.16.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-R77) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1697-R1702)
* Updated `wrangler` from `^3.98.0` to `^3.99.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL29-R77) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1825-R1839)
* Updated `runed` from `^0.19.0` to `^0.20.0` in `package.json` and `pnpm-lock.yaml`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R44) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15-R19) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1574-R1575)